### PR TITLE
Add further features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 composer.lock
+outputDir
 phpunit.xml
 vendor

--- a/src/CodeCreator.php
+++ b/src/CodeCreator.php
@@ -9,13 +9,19 @@ class CodeCreator
     /**
      * @var string
      */
+    private $defaultClass;
+    /**
+     * @var string
+     */
     private $defaultNamespace;
 
     /**
+     * @param string $defaultClass
      * @param string $defaultNamespace
      */
-    public function __construct($defaultNamespace)
+    public function __construct($defaultClass, $defaultNamespace)
     {
+        $this->defaultClass = $defaultClass;
         $this->defaultNamespace = $defaultNamespace;
     }
 
@@ -24,61 +30,59 @@ class CodeCreator
      * @return PhpNamespace[]
      */
     public function create($schema) {
-        if (!isset($schema->definitions)) {
+        if (!isset($schema->properties)) {
             return [];
         }
         $classes = [];
-        foreach ($schema->definitions as $name => $definition) {
-            $namespace = new PhpNamespace($this->defaultNamespace);
-            $class = $namespace->addClass($name)
-                            ->addImplement('\JsonSerializable');
-            $constructor = $class->addMethod('__construct');
-            $constructorComment = '';
-            $constructorBody = '';
-            $serializableArrayBody = '';
-            foreach ($definition->properties as $propertyName => $propertyAttributes) {
-                $jsonPropertyType = isset($propertyAttributes->type) ? $propertyAttributes->type : 'number';
-                switch ($jsonPropertyType) {
-                    case 'number':
-                        $propertyType = 'integer';
-                        break;
-                    case 'boolean':
-                    case 'string':
-                    default:
-                        $propertyType = $jsonPropertyType;
-                        break;
-                }
-                if (isset($propertyAttributes->enum)) {
-                    if (count($propertyAttributes->enum) > 1) {
-                        $propertyType = $name . ucfirst($propertyName);
-                        $classes[$propertyType] = $this->createEnum($propertyType, $propertyAttributes->enum);
-                        $classes['InvalidValueException'] = $this->createException('InvalidValueException');
-                        $constructorBody.= '$this->' . $propertyName . ' = $' . $propertyName . '->getValue();' . "\n";
-                        $constructor->addParameter($propertyName)
-                            ->setTypeHint($this->defaultNamespace . '\\' . $propertyType);
-                        $constructorComment.= "@param $propertyType \$$propertyName";
-                    } else {
-                        $constructorBody.= '$this->' . $propertyName . " = '" . $propertyAttributes->enum[0] . "';\n";
-                    }
-                } else {
-                    $constructorBody.= '$this->' . $propertyName . ' = $' . $propertyName . ';' . "\n";
-                    $constructor->addParameter($propertyName);
+        $namespace = new PhpNamespace($this->defaultNamespace);
+        $class = $namespace->addClass($this->defaultClass)
+                        ->addImplement('\JsonSerializable');
+        $constructor = $class->addMethod('__construct');
+        $constructorComment = '';
+        $constructorBody = '';
+        $serializableArrayBody = '';
+        foreach ($schema->properties as $propertyName => $propertyAttributes) {
+            $jsonPropertyType = isset($propertyAttributes->type) ? $propertyAttributes->type : 'number';
+            switch ($jsonPropertyType) {
+                case 'number':
+                    $propertyType = 'integer';
+                    break;
+                case 'boolean':
+                case 'string':
+                default:
+                    $propertyType = $jsonPropertyType;
+                    break;
+            }
+            if (isset($propertyAttributes->enum)) {
+                if (count($propertyAttributes->enum) > 1) {
+                    $propertyType = $this->defaultClass . ucfirst($propertyName);
+                    $classes[$propertyType] = $this->createEnum($propertyType, $propertyAttributes->enum);
+                    $classes['InvalidValueException'] = $this->createException('InvalidValueException');
+                    $constructorBody.= '$this->' . $propertyName . ' = $' . $propertyName . '->getValue();' . "\n";
+                    $constructor->addParameter($propertyName)
+                        ->setTypeHint($this->defaultNamespace . '\\' . $propertyType);
                     $constructorComment.= "@param $propertyType \$$propertyName";
+                } else {
+                    $constructorBody.= '$this->' . $propertyName . " = '" . $propertyAttributes->enum[0] . "';\n";
                 }
-                $class->addProperty($propertyName)
-                    ->setVisibility('private')
-                    ->addComment("@var $propertyType");
-                $serializableArrayBody.= "    '" . $propertyName . "'=>" . '$this->' . $propertyName . ",\n";
+            } else {
+                $constructorBody.= '$this->' . $propertyName . ' = $' . $propertyName . ';' . "\n";
+                $constructor->addParameter($propertyName);
+                $constructorComment.= "@param $propertyType \$$propertyName";
             }
-            if (!empty($constructorComment)) {
-                $constructor->addComment($constructorComment);
-            }
-            $constructor->addBody($constructorBody);
-            $serializableArray = "return [\n" . $serializableArrayBody . "];";
-            $class->addMethod('jsonSerialize')
-                ->addBody($serializableArray);
-            $classes[$name] = $namespace;
+            $class->addProperty($propertyName)
+                ->setVisibility('private')
+                ->addComment("@var $propertyType");
+            $serializableArrayBody.= "    '" . $propertyName . "'=>" . '$this->' . $propertyName . ",\n";
         }
+        if (!empty($constructorComment)) {
+            $constructor->addComment($constructorComment);
+        }
+        $constructor->addBody($constructorBody);
+        $serializableArray = "return [\n" . $serializableArrayBody . "];";
+        $class->addMethod('jsonSerialize')
+            ->addBody($serializableArray);
+        $classes[$this->defaultClass] = $namespace;
         return $classes;
     }
 

--- a/src/CodeCreator.php
+++ b/src/CodeCreator.php
@@ -68,13 +68,13 @@ class CodeCreator
                 $class->addProperty($propertyName)
                     ->setVisibility('private')
                     ->addComment("@var $propertyType");
-                $serializableArrayBody.= "'" . $propertyName . "'=>" . '$this->' . $propertyName . ",\n";
+                $serializableArrayBody.= "    '" . $propertyName . "'=>" . '$this->' . $propertyName . ",\n";
             }
             if (!empty($constructorComment)) {
                 $constructor->addComment($constructorComment);
             }
             $constructor->addBody($constructorBody);
-            $serializableArray = 'return [' . $serializableArrayBody . '];';
+            $serializableArray = "return [\n" . $serializableArrayBody . "];";
             $class->addMethod('jsonSerialize')
                 ->addBody($serializableArray);
             $classes[$name] = $namespace;

--- a/src/Console/GenerateCommand.php
+++ b/src/Console/GenerateCommand.php
@@ -32,14 +32,29 @@ class GenerateCommand extends Command {
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $outputDir = $input->getOption('outputDir');
-        $outputDirFiles = new Local($outputDir);
+        $outputDirPath = $input->getOption('outputDir');
+        $output->writeln('Setting output dir to ' . realpath($outputDirPath));
+        $outputDirFiles = new Local($outputDirPath);
         $outputDir = new Filesystem($outputDirFiles);
-        $codeCreator = new CodeCreator($input->getArgument('class'), $input->getArgument('namespace'));
+
+        $output->writeln('Deleting all files in output dir.');
+        $files = $outputDir->listContents();
+        foreach ($files as $file) {
+            $outputDir->delete($file['path']);
+        }
+
+        $defaultClass = $input->getArgument('class');
+        $defaultNamespace = $input->getArgument('namespace');
+        $output->writeln('Generating code in namespace ' . $defaultNamespace);
+        $output->writeln('    with top-level class ' . $defaultClass);
+        $codeCreator = new CodeCreator($defaultClass, $defaultNamespace);
         $generator = new Generator($outputDir, $codeCreator);
         $localFiles = new Local('.');
         $schemaDir = new Filesystem($localFiles);
-        $jsonSchema = $schemaDir->read($input->getArgument('schema'));
+
+        $schemaPath = $input->getArgument('schema');
+        $output->writeln('Using JSON Schema in '. realpath($schemaPath));
+        $jsonSchema = $schemaDir->read($schemaPath);
         $generator->generate($jsonSchema);
     }
 }

--- a/src/Console/GenerateCommand.php
+++ b/src/Console/GenerateCommand.php
@@ -23,6 +23,7 @@ class GenerateCommand extends Command {
             ->setDefinition(
                 new InputDefinition([
                     new InputArgument('schema', InputArgument::REQUIRED),
+                    new InputArgument('class', InputArgument::REQUIRED),
                     new InputArgument('namespace', InputArgument::REQUIRED),
                     new InputOption('outputDir', 'o', InputOption::VALUE_REQUIRED, 'Target dir for output files', './outputDir/'),
                 ])
@@ -34,7 +35,7 @@ class GenerateCommand extends Command {
         $outputDir = $input->getOption('outputDir');
         $outputDirFiles = new Local($outputDir);
         $outputDir = new Filesystem($outputDirFiles);
-        $codeCreator = new CodeCreator($input->getArgument('namespace'));
+        $codeCreator = new CodeCreator($input->getArgument('class'), $input->getArgument('namespace'));
         $generator = new Generator($outputDir, $codeCreator);
         $localFiles = new Local('.');
         $schemaDir = new Filesystem($localFiles);

--- a/tests/CodeCreatorTest.php
+++ b/tests/CodeCreatorTest.php
@@ -10,14 +10,12 @@ class CodeCreatorTest extends \PHPUnit\Framework\TestCase
 {
     public function testCreatesClassWithIntegerProperty()
     {
-        $schema = json_decode('{"definitions": {
-            "IntegerProperty": {
-                "properties": {
-                    "foo": {"type": "number"}
-                }
+        $schema = json_decode('{
+            "properties": {
+                "foo": {"type": "number"}
             }
-        }}');
-        $codeCreator = new CodeCreator('Elsevier\JSONSchemaPHPGenerator\Examples');
+        }');
+        $codeCreator = new CodeCreator('IntegerProperty', 'Elsevier\JSONSchemaPHPGenerator\Examples');
 
         $code = $codeCreator->create($schema);
 
@@ -27,14 +25,12 @@ class CodeCreatorTest extends \PHPUnit\Framework\TestCase
     
     public function testCreatesClassWithStringProperty()
     {
-        $schema = json_decode('{"definitions": {
-            "StringProperty": {
-                "properties": {
-                    "foo": {"type": "string"}
-                }
+        $schema = json_decode('{
+            "properties": {
+                "foo": {"type": "string"}
             }
-        }}');
-        $codeCreator = new CodeCreator('Elsevier\JSONSchemaPHPGenerator\Examples');
+        }');
+        $codeCreator = new CodeCreator('StringProperty', 'Elsevier\JSONSchemaPHPGenerator\Examples');
 
         $code = $codeCreator->create($schema);
 
@@ -44,14 +40,12 @@ class CodeCreatorTest extends \PHPUnit\Framework\TestCase
     
     public function testCreatesClassWithBooleanProperty()
     {
-        $schema = json_decode('{"definitions": {
-            "BooleanProperty": {
-                "properties": {
-                    "foo": {"type": "boolean"}
-                }
+        $schema = json_decode('{
+            "properties": {
+                "foo": {"type": "boolean"}
             }
-        }}');
-        $codeCreator = new CodeCreator('Elsevier\JSONSchemaPHPGenerator\Examples');
+        }');
+        $codeCreator = new CodeCreator('BooleanProperty', 'Elsevier\JSONSchemaPHPGenerator\Examples');
 
         $code = $codeCreator->create($schema);
 
@@ -61,19 +55,17 @@ class CodeCreatorTest extends \PHPUnit\Framework\TestCase
 
     public function testCreatesClassWithEnumPropertyWithSingleValueAsConstant()
     {
-        $schema = json_decode('{"definitions": {
-            "EnumPropertyWithSingleValue": {
-                "properties": {
-                    "foo": {
-                        "enum": [
-                            "Bar"
-                        ],
-                        "type": "string"
-                    }
+        $schema = json_decode('{
+            "properties": {
+                "foo": {
+                    "enum": [
+                        "Bar"
+                    ],
+                    "type": "string"
                 }
             }
-        }}');
-        $codeCreator = new CodeCreator('Elsevier\JSONSchemaPHPGenerator\Examples');
+        }');
+        $codeCreator = new CodeCreator('EnumPropertyWithSingleValue', 'Elsevier\JSONSchemaPHPGenerator\Examples');
 
         $code = $codeCreator->create($schema);
 
@@ -83,20 +75,18 @@ class CodeCreatorTest extends \PHPUnit\Framework\TestCase
 
     public function testWithEnumPropertyCreatesTargetClass()
     {
-        $schema = json_decode('{"definitions": {
-            "EnumProperty": {
-                "properties": {
-                    "foo": {
-                        "enum": [
-                            "Foo",
-                            "Bar"
-                        ],
-                        "type": "string"
-                    }
+        $schema = json_decode('{
+            "properties": {
+                "foo": {
+                    "enum": [
+                        "Foo",
+                        "Bar"
+                    ],
+                    "type": "string"
                 }
             }
-        }}');
-        $codeCreator = new CodeCreator('Elsevier\JSONSchemaPHPGenerator\Examples');
+        }');
+        $codeCreator = new CodeCreator('EnumProperty', 'Elsevier\JSONSchemaPHPGenerator\Examples');
 
         $code = $codeCreator->create($schema);
 
@@ -108,20 +98,18 @@ class CodeCreatorTest extends \PHPUnit\Framework\TestCase
 
     public function testWithEnumPropertyCreatesEnumClass()
     {
-        $schema = json_decode('{"definitions": {
-            "EnumProperty": {
-                "properties": {
-                    "foo": {
-                        "enum": [
-                            "Foo",
-                            "Bar"
-                        ],
-                        "type": "string"
-                    }
+        $schema = json_decode('{
+            "properties": {
+                "foo": {
+                    "enum": [
+                        "Foo",
+                        "Bar"
+                    ],
+                    "type": "string"
                 }
             }
-        }}');
-        $codeCreator = new CodeCreator('Elsevier\JSONSchemaPHPGenerator\Examples');
+        }');
+        $codeCreator = new CodeCreator('EnumProperty', 'Elsevier\JSONSchemaPHPGenerator\Examples');
 
         $code = $codeCreator->create($schema);
 
@@ -131,20 +119,18 @@ class CodeCreatorTest extends \PHPUnit\Framework\TestCase
 
     public function testWithEnumPropertyCreatesExceptionUsedByEnum()
     {
-        $schema = json_decode('{"definitions": {
-            "EnumProperty": {
-                "properties": {
-                    "foo": {
-                        "enum": [
-                            "Foo",
-                            "Bar"
-                        ],
-                        "type": "string"
-                    }
+        $schema = json_decode('{
+            "properties": {
+                "foo": {
+                    "enum": [
+                        "Foo",
+                        "Bar"
+                    ],
+                    "type": "string"
                 }
             }
-        }}');
-        $codeCreator = new CodeCreator('Elsevier\JSONSchemaPHPGenerator\Examples');
+        }');
+        $codeCreator = new CodeCreator('EnumProperty', 'Elsevier\JSONSchemaPHPGenerator\Examples');
 
         $code = $codeCreator->create($schema);
 

--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -13,7 +13,7 @@ class GeneratorTest extends \PHPUnit\Framework\TestCase
 {
     public function testEmptySchemaCreatesNoFiles() {
         $fileSystem = $this->createFilesystem();
-        $codeCreator = new CodeCreator('Elsevier\JSONSchemaPHPGenerator\Examples');
+        $codeCreator = new CodeCreator('FooBar', 'Elsevier\JSONSchemaPHPGenerator\Examples');
         $generator = new Generator($fileSystem, $codeCreator);
 
         $generator->generate('{}');
@@ -22,16 +22,14 @@ class GeneratorTest extends \PHPUnit\Framework\TestCase
     }
 
     public function testBasicSchemaCreatesOneClassFile() {
-        $schema = '{"definitions": {
-            "FooBar": {
-                "properties": {
-                    "foo": {"type": "integer"},
-                    "bar": {"type": "string"}
-                }
+        $schema = '{
+            "properties": {
+                "foo": {"type": "integer"},
+                "bar": {"type": "string"}
             }
-        }}';
+        }';
         $fileSystem = $this->createFilesystem();
-        $codeCreator = new CodeCreator('Elsevier\JSONSchemaPHPGenerator\Examples');
+        $codeCreator = new CodeCreator('FooBar', 'Elsevier\JSONSchemaPHPGenerator\Examples');
         $generator = new Generator($fileSystem, $codeCreator);
 
         $generator->generate($schema);
@@ -41,7 +39,7 @@ class GeneratorTest extends \PHPUnit\Framework\TestCase
 
     public function testInvalidJsonThrowsException() {
         $schema = '{';
-        $codeCreator = new CodeCreator('Elsevier\JSONSchemaPHPGenerator\Examples');
+        $codeCreator = new CodeCreator('FooBar', 'Elsevier\JSONSchemaPHPGenerator\Examples');
         $generator = new Generator($this->createFilesystem(), $codeCreator);
 
         $this->setExpectedException(InvalidJsonException::class);
@@ -49,10 +47,12 @@ class GeneratorTest extends \PHPUnit\Framework\TestCase
     }
 
     public function testInvalidJsonSchemaThrowsException() {
-        $schema = '{"definitions": {
-            "Baz": "invalid"
-        }}';
-        $codeCreator = new CodeCreator('Elsevier\JSONSchemaPHPGenerator\Examples');
+        $schema = '{
+            "properties": {
+                "Baz": "invalid"
+            }
+        }';
+        $codeCreator = new CodeCreator('FooBar', 'Elsevier\JSONSchemaPHPGenerator\Examples');
         $generator = new Generator($this->createFilesystem(), $codeCreator);
 
         $this->setExpectedException(InvalidSchemaException::class);


### PR DESCRIPTION
Sorry, a few different tweaks included in this PR (see commit messages for all the details).

Main fix is that we were previously working on the assumption that every object was in the `definitions` property of the schema. Turns out that this isn't the case and the top-level of the schema itself represents an object (in our particular case it's the IOrder object).

I'd like to do a refactor of `CodeCreator` to pull out individual property types into their own classes to clean up the `create()` method so I'd like to get these changes merged first.