### PR TITLE
Add linting to project and fix issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ php:
 before_script:
   - composer self-update
   - composer install --prefer-source --no-interaction --dev
+  - composer lint
   - php -l tests/examples/
 
 matrix:

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,8 @@
     "require-dev": {
         "json-schema/JSON-Schema-Test-Suite": "1.2.0",
         "phpunit/phpunit": "^4.8.36",
-        "hamcrest/hamcrest-php": "^2.0"
+        "hamcrest/hamcrest-php": "^2.0",
+        "squizlabs/php_codesniffer": "^3.1"
     },
     "autoload": {
         "psr-4": { "Elsevier\\JSONSchemaPHPGenerator\\": "src/" }
@@ -45,7 +46,8 @@
         ]
     },
     "scripts": {
-        "test" : "vendor/bin/phpunit"
+        "test": "vendor/bin/phpunit",
+        "lint": "vendor/bin/phpcs --standard=PSR2 --exclude=Generic.Files.LineLength src/"
     },
     "bin": [
         "bin/php-json-schema-generate"

--- a/src/CodeCreator.php
+++ b/src/CodeCreator.php
@@ -35,7 +35,8 @@ class CodeCreator
      * @param string $schema - A valid JSON Schema
      * @return PhpNamespace[]
      */
-    public function create($schema) {
+    public function create($schema)
+    {
         if (!isset($schema->properties)) {
             return [];
         }
@@ -74,7 +75,8 @@ class CodeCreator
      * @param array $values
      * @return PhpNamespace
      */
-    public function createEnum($className, $values) {
+    public function createEnum($className, $values)
+    {
         $namespace = new PhpNamespace($this->defaultNamespace);
         $class = $namespace->addClass($className);
         foreach ($values as $value) {
@@ -109,7 +111,8 @@ class CodeCreator
      * @param string $className
      * @return PhpNamespace
      */
-    public function createException($className) {
+    public function createException($className)
+    {
         $namespace = new PhpNamespace($this->defaultNamespace);
         $namespace->addClass($className)
             ->addExtend('\Exception');

--- a/src/Console/GenerateCommand.php
+++ b/src/Console/GenerateCommand.php
@@ -13,7 +13,8 @@ use Elsevier\JSONSchemaPHPGenerator\Generator;
 use League\Flysystem\Adapter\Local;
 use League\Flysystem\Filesystem;
 
-class GenerateCommand extends Command {
+class GenerateCommand extends Command
+{
 
     protected function configure()
     {

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -31,7 +31,8 @@ class Generator
      * @throws InvalidJsonException
      * @throws InvalidSchemaException
      */
-    public function generate($rawSchema) {
+    public function generate($rawSchema)
+    {
         $schema = json_decode($rawSchema);
         if (json_last_error() !== JSON_ERROR_NONE) {
             throw new InvalidJsonException('JSON Schema is invalid JSON.');

--- a/src/GeneratorException.php
+++ b/src/GeneratorException.php
@@ -2,4 +2,6 @@
 
 namespace Elsevier\JSONSchemaPHPGenerator;
 
-class GeneratorException extends \Exception {}
+class GeneratorException extends \Exception
+{
+}

--- a/src/InvalidJsonException.php
+++ b/src/InvalidJsonException.php
@@ -2,4 +2,6 @@
 
 namespace Elsevier\JSONSchemaPHPGenerator;
 
-class InvalidJsonException extends GeneratorException {}
+class InvalidJsonException extends GeneratorException
+{
+}

--- a/src/InvalidSchemaException.php
+++ b/src/InvalidSchemaException.php
@@ -2,4 +2,6 @@
 
 namespace Elsevier\JSONSchemaPHPGenerator;
 
-class InvalidSchemaException extends GeneratorException {}
+class InvalidSchemaException extends GeneratorException
+{
+}

--- a/src/Properties/Factory.php
+++ b/src/Properties/Factory.php
@@ -11,7 +11,8 @@ class Factory
      * @param string $namespace
      * @return Property
      */
-    public function create($name, $attributes, $className, $namespace) {
+    public function create($name, $attributes, $className, $namespace)
+    {
         if (!isset($attributes->type)) {
             return new UntypedProperty();
         }

--- a/src/Properties/ScalarProperty.php
+++ b/src/Properties/ScalarProperty.php
@@ -30,7 +30,8 @@ class ScalarProperty implements Property
     /**
      * @inheritdoc
      */
-    public function constructorBody() {
+    public function constructorBody()
+    {
         return '$this->' . $this->name . ' = $' . $this->name . ';' . "\n";
     }
 
@@ -45,7 +46,8 @@ class ScalarProperty implements Property
     /**
      * @inheritdoc
      */
-    public function addConstructorParameter(Method $constructor) {
+    public function addConstructorParameter(Method $constructor)
+    {
         $constructor->addParameter($this->name);
         return $constructor;
     }
@@ -64,7 +66,8 @@ class ScalarProperty implements Property
     /**
      * @inheritdoc
      */
-    public function serializingCode(){
+    public function serializingCode()
+    {
         return "    '" . $this->name . "'=>" . '$this->' . $this->name . ",\n";
     }
 

--- a/src/Properties/StringProperty.php
+++ b/src/Properties/StringProperty.php
@@ -8,7 +8,7 @@ class StringProperty extends ScalarProperty
      * @param string $name
      */
     public function __construct($name)
-{
-    parent::__construct($name, 'string');
-}
+    {
+        parent::__construct($name, 'string');
+    }
 }

--- a/src/Properties/UntypedProperty.php
+++ b/src/Properties/UntypedProperty.php
@@ -6,12 +6,14 @@ use Elsevier\JSONSchemaPHPGenerator\CodeCreator;
 use Nette\PhpGenerator\ClassType;
 use Nette\PhpGenerator\Method;
 
-class UntypedProperty implements Property {
+class UntypedProperty implements Property
+{
 
     /**
      * @inheritdoc
      */
-    public function constructorBody() {
+    public function constructorBody()
+    {
         return '';
     }
 
@@ -26,7 +28,8 @@ class UntypedProperty implements Property {
     /**
      * @inheritdoc
      */
-    public function addConstructorParameter(Method $constructor) {
+    public function addConstructorParameter(Method $constructor)
+    {
         return $constructor;
     }
 
@@ -41,7 +44,8 @@ class UntypedProperty implements Property {
     /**
      * @inheritdoc
      */
-    public function serializingCode(){
+    public function serializingCode()
+    {
         return '';
     }
 


### PR DESCRIPTION
Added linting/coding standards.

Most of the changes are fixing the formatting to follow the rules.

I have used the PSR2 standard for the rules, with the exception of warning on length of lines.
Most relevant changes in the PR are that we have added a `lint` command to composer for ease of use, and that we have added the linting to the Travis build.