### PR TITLE
V0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+== Version 0.6.0 ==
+
+- Switch to use PHP float type for number properties
+
 == Version 0.5.0 ==
 
 - Add support for reference properties and object definitions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 == Version 0.6.0 ==
 
 - Switch to use PHP float type for number properties
+- Add support for properties that contain an array of objects
 
 == Version 0.5.0 ==
 

--- a/README.md
+++ b/README.md
@@ -16,4 +16,4 @@ So far this is only a partial implementation of the JSON Schema. See tests for w
 - Add warning/confirm step to console command about file delete
 - Add option to read configs from file rather than pass in as args
 - Make namespace argument optional (and hence create output without any namespaces)
-- Add support for arrays, nulls and sub-references
+- Add support for arrays and nulls

--- a/README.md
+++ b/README.md
@@ -16,4 +16,6 @@ So far this is only a partial implementation of the JSON Schema. See tests for w
 - Add warning/confirm step to console command about file delete
 - Add option to read configs from file rather than pass in as args
 - Make namespace argument optional (and hence create output without any namespaces)
-- Add support for arrays and nulls
+- Add support for nulls
+- Ensure generator can handle all valid JSON Schemas (Schemata?)
+- Parse schema to AST before generating code (so we can create different code generators)

--- a/src/CodeCreator.php
+++ b/src/CodeCreator.php
@@ -138,6 +138,7 @@ class CodeCreator
                 $property->addSetterTo($class);
                 $serializableOptionalProperties .= $property->optionalSerializingCode();
             }
+            $property->addMethodsTo($class);
         }
         $constructorComment = array_filter($constructorComment, function ($comment) {
             return !empty($comment);

--- a/src/Properties/ArrayProperty.php
+++ b/src/Properties/ArrayProperty.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Elsevier\JSONSchemaPHPGenerator\Properties;
+
+use Nette\PhpGenerator\ClassType;
+use Nette\PhpGenerator\Method;
+
+class ArrayProperty extends ObjectProperty
+{
+    /**
+     * @inheritdoc
+     */
+    public function constructorComment()
+    {
+        return '@param ' . $this->type . '[] $' . $this->name;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function addTo(ClassType $class)
+    {
+        $class->addProperty($this->name)
+            ->setVisibility('private')
+            ->addComment("@var " . $this->type  ."[]");
+        return $class;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function addParameterTo(Method $constructor)
+    {
+        $constructor->addParameter($this->name)
+            ->setTypeHint('array');
+        return $constructor;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function constructorBody()
+    {
+        return '$this->' . $this->name . ' = $this->filterFor' . $this->type . '($' . $this->name . ');' . "\n";
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function addSetterTo(ClassType $class)
+    {
+        $class->addMethod('set' . ucfirst($this->name))
+            ->addComment('@param ' . $this->type . '[] $value')
+            ->addBody('$this->' . $this->name . ' = $this->filterFor' . $this->type . '($value);')
+            ->addParameter('value')
+            ->setTypeHint('array');
+        return $class;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function addMethodsTo(ClassType $class)
+    {
+        $class->addMethod('filterFor' . $this->type)
+            ->setVisibility('private')
+            ->addComment("@param array \$array\n@return $this->type[]")
+            ->addBody(
+                'return array_filter($array, function ($item) {' . "\n" .
+                '   return $item instanceof ' . $this->type . ';' . "\n" .
+                '});'
+            )
+            ->addParameter('array')
+            ->setTypeHint('array');
+        return $class;
+    }
+}

--- a/src/Properties/EnumProperty.php
+++ b/src/Properties/EnumProperty.php
@@ -121,4 +121,12 @@ class EnumProperty implements Property
             ->setTypeHint($this->defaultNamespace . '\\' . $this->enumName);
         return $class;
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function addMethodsTo(ClassType $class)
+    {
+        return $class;
+    }
 }

--- a/src/Properties/Factory.php
+++ b/src/Properties/Factory.php
@@ -31,6 +31,8 @@ class Factory
             return new StringProperty($name);
         } elseif ($attributes->type === 'boolean') {
             return new BooleanProperty($name);
+        } elseif ($attributes->type === 'array') {
+            return new ArrayProperty($name, $attributes->items->{'$ref'}, $namespace);
         }
         return new UntypedProperty();
     }

--- a/src/Properties/Factory.php
+++ b/src/Properties/Factory.php
@@ -26,7 +26,7 @@ class Factory
             }
         }
         if ($attributes->type === 'number') {
-            return new IntegerProperty($name);
+            return new FloatProperty($name);
         } elseif ($attributes->type === 'string' && !isset($attributes->enum)) {
             return new StringProperty($name);
         } elseif ($attributes->type === 'boolean') {

--- a/src/Properties/FloatProperty.php
+++ b/src/Properties/FloatProperty.php
@@ -2,13 +2,13 @@
 
 namespace Elsevier\JSONSchemaPHPGenerator\Properties;
 
-class IntegerProperty extends ScalarProperty
+class FloatProperty extends ScalarProperty
 {
     /**
      * @param string $name
      */
     public function __construct($name)
     {
-        parent::__construct($name, 'integer');
+        parent::__construct($name, 'float');
     }
 }

--- a/src/Properties/Property.php
+++ b/src/Properties/Property.php
@@ -51,4 +51,10 @@ interface Property
      * @return ClassType
      */
     public function addSetterTo(ClassType $class);
+
+    /**
+     * @param ClassType $class
+     * @return ClassType
+     */
+    public function addMethodsTo(ClassType $class);
 }

--- a/src/Properties/ScalarProperty.php
+++ b/src/Properties/ScalarProperty.php
@@ -100,4 +100,12 @@ class ScalarProperty implements Property
             ->addParameter('value');
         return $class;
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function addMethodsTo(ClassType $class)
+    {
+        return $class;
+    }
 }

--- a/src/Properties/UntypedProperty.php
+++ b/src/Properties/UntypedProperty.php
@@ -72,4 +72,12 @@ class UntypedProperty implements Property
     {
         return $class;
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function addMethodsTo(ClassType $class)
+    {
+        return $class;
+    }
 }

--- a/tests/CodeCreatorTest.php
+++ b/tests/CodeCreatorTest.php
@@ -6,7 +6,7 @@ use Elsevier\JSONSchemaPHPGenerator\CodeCreator;
 
 class CodeCreatorTest extends \PHPUnit\Framework\TestCase
 {
-    public function testCreatesClassWithIntegerProperty()
+    public function testCreatesClassWithNumberProperty()
     {
         $schema = json_decode('{
             "properties": {
@@ -16,12 +16,12 @@ class CodeCreatorTest extends \PHPUnit\Framework\TestCase
                 "foo"
             ]
         }');
-        $codeCreator = new CodeCreator('IntegerProperty', 'Elsevier\JSONSchemaPHPGenerator\Examples');
+        $codeCreator = new CodeCreator('FloatProperty', 'Elsevier\JSONSchemaPHPGenerator\Examples');
 
         $code = $codeCreator->create($schema);
 
         assertThat($code, arrayWithSize(1));
-        assertThat($code, hasClassThatMatchesTheExample('IntegerProperty'));
+        assertThat($code, hasClassThatMatchesTheExample('FloatProperty'));
     }
     
     public function testCreatesClassWithStringProperty()

--- a/tests/CodeCreatorTest.php
+++ b/tests/CodeCreatorTest.php
@@ -291,4 +291,34 @@ class CodeCreatorTest extends \PHPUnit\Framework\TestCase
         assertThat($code, arrayWithSize(atLeast(1)));
         assertThat($code, hasClassThatMatchesTheExample('SubReferenceEnumFoo'));
     }
+
+    public function testWithArrayOfReferencedObjects()
+    {
+        $schema = json_decode('{
+            "properties": {
+                "bar": {
+                    "items": {
+                        "$ref": "#/definitions/SubReference"
+                    },
+                    "type": "array"
+                },
+                "foo": {
+                    "items": {
+                        "$ref": "#/definitions/SubReference"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object",
+            "required": [
+                "bar"
+            ]
+        }');
+        $codeCreator = new CodeCreator('ArrayOfObjects', 'Elsevier\JSONSchemaPHPGenerator\Examples');
+
+        $code = $codeCreator->create($schema);
+
+        assertThat($code, arrayWithSize(atLeast(1)));
+        assertThat($code, hasClassThatMatchesTheExample('ArrayOfObjects'));
+    }
 }

--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -25,7 +25,7 @@ class GeneratorTest extends \PHPUnit\Framework\TestCase
     {
         $schema = '{
             "properties": {
-                "foo": {"type": "integer"},
+                "foo": {"type": "number"},
                 "bar": {"type": "string"}
             }
         }';

--- a/tests/Properties/FactoryTest.php
+++ b/tests/Properties/FactoryTest.php
@@ -6,7 +6,7 @@ use Elsevier\JSONSchemaPHPGenerator\Properties\Factory;
 use Elsevier\JSONSchemaPHPGenerator\Properties\BooleanProperty;
 use Elsevier\JSONSchemaPHPGenerator\Properties\ConstantProperty;
 use Elsevier\JSONSchemaPHPGenerator\Properties\EnumProperty;
-use Elsevier\JSONSchemaPHPGenerator\Properties\IntegerProperty;
+use Elsevier\JSONSchemaPHPGenerator\Properties\FloatProperty;
 use Elsevier\JSONSchemaPHPGenerator\Properties\ObjectProperty;
 use Elsevier\JSONSchemaPHPGenerator\Properties\StringProperty;
 use Elsevier\JSONSchemaPHPGenerator\Properties\UntypedProperty;
@@ -26,7 +26,7 @@ class FactoryTest extends \PHPUnit\Framework\TestCase
 
     public function testWithInvalidTypeReturnsUntypedProperty()
     {
-        $attributes = json_decode('{ "type": "integer" }');
+        $attributes = json_decode('{ "type": "foobar" }');
 
         $factory = new Factory();
         $property = $factory->create('FooBar', $attributes, 'Class', 'Example\\Namespace');
@@ -34,14 +34,14 @@ class FactoryTest extends \PHPUnit\Framework\TestCase
         assertThat($property, is(anInstanceOf(UntypedProperty::class)));
     }
 
-    public function testNumberReturnsIntegerProperty()
+    public function testNumberReturnsFloatProperty()
     {
         $attributes = json_decode('{ "type": "number"}');
 
         $factory = new Factory();
         $property = $factory->create('FooBar', $attributes, 'Class', 'Example\\Namespace');
 
-        assertThat($property, is(anInstanceOf(IntegerProperty::class)));
+        assertThat($property, is(anInstanceOf(FloatProperty::class)));
     }
 
     public function testStringReturnsStringProperty()

--- a/tests/Properties/FactoryTest.php
+++ b/tests/Properties/FactoryTest.php
@@ -3,6 +3,7 @@
 namespace Elsevier\JSONSchemaPHPGenerator\Tests\Properties;
 
 use Elsevier\JSONSchemaPHPGenerator\Properties\Factory;
+use Elsevier\JSONSchemaPHPGenerator\Properties\ArrayProperty;
 use Elsevier\JSONSchemaPHPGenerator\Properties\BooleanProperty;
 use Elsevier\JSONSchemaPHPGenerator\Properties\ConstantProperty;
 use Elsevier\JSONSchemaPHPGenerator\Properties\EnumProperty;
@@ -108,5 +109,23 @@ class FactoryTest extends \PHPUnit\Framework\TestCase
 
         assertThat($property, is(anInstanceOf(ObjectProperty::class)));
         assertThat($property->constructorComment(), is('@param SubReference $FooBar'));
+    }
+
+    public function testArrayProperty()
+    {
+        $attributes = json_decode('
+            {
+                "items": {
+                    "$ref": "#/definitions/SubReference"
+                },
+                "type": "array"
+            }
+        ');
+
+        $factory = new Factory();
+        $property = $factory->create('FooBar', $attributes, 'Class', 'Example\\Namespace');
+
+        assertThat($property, is(anInstanceOf(ArrayProperty::class)));
+        assertThat($property->constructorComment(), is('@param SubReference[] $FooBar'));
     }
 }

--- a/tests/examples/ArrayOfObjects.php
+++ b/tests/examples/ArrayOfObjects.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Elsevier\JSONSchemaPHPGenerator\Examples;
+
+class ArrayOfObjects implements \JsonSerializable
+{
+    /** @var SubReference[] */
+    private $bar;
+    /** @var SubReference[] */
+    private $foo;
+
+    /**
+     * @param SubReference[] $bar
+     */
+    public function __construct(array $bar)
+    {
+        $this->bar = $this->filterForSubReference($bar);
+    }
+
+    /**
+     * @param array $array
+     * @return SubReference[]
+     */
+    private function filterForSubReference(array $array)
+    {
+        return array_filter($array, function ($item) {
+            return $item instanceof SubReference;
+        });
+    }
+
+    /**
+     * @param SubReference[] $value
+     */
+    public function setFoo(array $value)
+    {
+        $this->foo = $this->filterForSubReference($value);
+    }
+
+    public function jsonSerialize()
+    {
+        $values = [
+            'bar' => $this->bar,
+        ];
+        if ($this->foo) {
+            $values['foo'] = $this->foo;
+        }
+        return $values;
+    }
+}

--- a/tests/examples/FloatProperty.php
+++ b/tests/examples/FloatProperty.php
@@ -2,13 +2,13 @@
 
 namespace Elsevier\JSONSchemaPHPGenerator\Examples;
 
-class IntegerProperty implements \JsonSerializable
+class FloatProperty implements \JsonSerializable
 {
-    /** @var integer */
+    /** @var float */
     private $foo;
 
     /**
-     * @param integer $foo
+     * @param float $foo
      */
     public function __construct($foo)
     {


### PR DESCRIPTION
- Switch to use PHP float type for number properties
- Add support for properties that contain an array of objects

Want to do some refactoring of the Property objects so put this up for review first to avoid too much noise.