### PR TITLE
Cast scalar types

### DIFF
--- a/src/Properties/BooleanProperty.php
+++ b/src/Properties/BooleanProperty.php
@@ -2,6 +2,8 @@
 
 namespace Elsevier\JSONSchemaPHPGenerator\Properties;
 
+use Nette\PhpGenerator\Method;
+
 class BooleanProperty extends TypedProperty
 {
     /**
@@ -10,5 +12,14 @@ class BooleanProperty extends TypedProperty
     public function __construct($name)
     {
         parent::__construct($name, 'boolean');
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function addConstructorBody(Method $constructor)
+    {
+        $constructor->addBody("\$this->{$this->name} = (bool)\${$this->name};");
+        return $constructor;
     }
 }

--- a/src/Properties/FloatProperty.php
+++ b/src/Properties/FloatProperty.php
@@ -2,6 +2,8 @@
 
 namespace Elsevier\JSONSchemaPHPGenerator\Properties;
 
+use Nette\PhpGenerator\Method;
+
 class FloatProperty extends TypedProperty
 {
     /**
@@ -10,5 +12,14 @@ class FloatProperty extends TypedProperty
     public function __construct($name)
     {
         parent::__construct($name, 'float');
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function addConstructorBody(Method $constructor)
+    {
+        $constructor->addBody("\$this->{$this->name} = (float)\${$this->name};");
+        return $constructor;
     }
 }

--- a/src/Properties/StringProperty.php
+++ b/src/Properties/StringProperty.php
@@ -2,6 +2,8 @@
 
 namespace Elsevier\JSONSchemaPHPGenerator\Properties;
 
+use Nette\PhpGenerator\Method;
+
 class StringProperty extends TypedProperty
 {
     /**
@@ -10,5 +12,14 @@ class StringProperty extends TypedProperty
     public function __construct($name)
     {
         parent::__construct($name, 'string');
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function addConstructorBody(Method $constructor)
+    {
+        $constructor->addBody("\$this->{$this->name} = (string)\${$this->name};");
+        return $constructor;
     }
 }

--- a/tests/JSONOutput/BooleanPropertyTest.php
+++ b/tests/JSONOutput/BooleanPropertyTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Elsevier\JSONSchemaPHPGenerator\Tests\JSONOutput;
+
+use Elsevier\JSONSchemaPHPGenerator\Examples\BooleanProperty;
+use PHPUnit\Framework\TestCase;
+
+class BooleanPropertyTest extends TestCase
+{
+    public function testReturnsBooleanValue()
+    {
+        $object = new BooleanProperty(true);
+        $json = json_encode($object);
+
+        $expected = '{
+            "foo": true
+        }';
+        assertThat($json, matchesJSONOutput($expected));
+    }
+
+    public function testCastsNullToFalse()
+    {
+        $object = new BooleanProperty(null);
+        $json = json_encode($object);
+
+        $expected = '{
+            "foo": false
+        }';
+        assertThat($json, matchesJSONOutput($expected));
+    }
+}

--- a/tests/JSONOutput/FloatPropertyTest.php
+++ b/tests/JSONOutput/FloatPropertyTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Elsevier\JSONSchemaPHPGenerator\Tests\JSONOutput;
+
+use Elsevier\JSONSchemaPHPGenerator\Examples\FloatProperty;
+use PHPUnit\Framework\TestCase;
+
+class FloatPropertyTest extends TestCase
+{
+    public function testReturnsFloatValue()
+    {
+        $object = new FloatProperty(2.5);
+        $json = json_encode($object);
+
+        $expected = '{
+            "foo": 2.5
+        }';
+        assertThat($json, matchesJSONOutput($expected));
+    }
+
+    public function testReturnsIntegerValue()
+    {
+        $object = new FloatProperty(2);
+        $json = json_encode($object);
+
+        $expected = '{
+            "foo": 2
+        }';
+        assertThat($json, matchesJSONOutput($expected));
+    }
+
+    public function testCastsNullToEmptyString()
+    {
+        $object = new FloatProperty(null);
+        $json = json_encode($object);
+
+        $expected = '{
+            "foo": 0
+        }';
+        assertThat($json, matchesJSONOutput($expected));
+    }
+}

--- a/tests/JSONOutput/StringPropertyTest.php
+++ b/tests/JSONOutput/StringPropertyTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Elsevier\JSONSchemaPHPGenerator\Tests\JSONOutput;
+
+use Elsevier\JSONSchemaPHPGenerator\Examples\StringProperty;
+use PHPUnit\Framework\TestCase;
+
+class StringPropertyTest extends TestCase
+{
+    public function testReturnsBasicString()
+    {
+        $object = new StringProperty('bar');
+        $json = json_encode($object);
+
+        $expected = '{
+            "foo": "bar"
+        }';
+        assertThat($json, matchesJSONOutput($expected));
+    }
+
+    public function testCastsNullToEmptyString()
+    {
+        $object = new StringProperty(null);
+        $json = json_encode($object);
+
+        $expected = '{
+            "foo": ""
+        }';
+        assertThat($json, matchesJSONOutput($expected));
+    }
+}

--- a/tests/examples/BooleanProperty.php
+++ b/tests/examples/BooleanProperty.php
@@ -14,7 +14,7 @@ class BooleanProperty implements \JsonSerializable
      */
     public function __construct($foo)
     {
-        $this->foo = $foo;
+        $this->foo = (bool)$foo;
     }
 
     /**

--- a/tests/examples/ConcreteClassOne.php
+++ b/tests/examples/ConcreteClassOne.php
@@ -12,7 +12,7 @@ class ConcreteClassOne implements \JsonSerializable, IBar
      */
     public function __construct($foo)
     {
-        $this->foo = $foo;
+        $this->foo = (string)$foo;
     }
 
     public function jsonSerialize()

--- a/tests/examples/ConcreteClassTwo.php
+++ b/tests/examples/ConcreteClassTwo.php
@@ -12,7 +12,7 @@ class ConcreteClassTwo implements \JsonSerializable, IBar
      */
     public function __construct($foo)
     {
-        $this->foo = $foo;
+        $this->foo = (string)$foo;
     }
 
     public function jsonSerialize()

--- a/tests/examples/FloatProperty.php
+++ b/tests/examples/FloatProperty.php
@@ -12,7 +12,7 @@ class FloatProperty implements \JsonSerializable
      */
     public function __construct($foo)
     {
-        $this->foo = $foo;
+        $this->foo = (float)$foo;
     }
 
     public function jsonSerialize()

--- a/tests/examples/MultipleProperties.php
+++ b/tests/examples/MultipleProperties.php
@@ -20,9 +20,9 @@ class MultipleProperties implements \JsonSerializable
      */
     public function __construct($bool, MultiplePropertiesEnum $enum, $string)
     {
-        $this->bool = $bool;
+        $this->bool = (bool)$bool;
         $this->enum = $enum;
-        $this->string = $string;
+        $this->string = (string)$string;
     }
 
     public function jsonSerialize()

--- a/tests/examples/StringProperty.php
+++ b/tests/examples/StringProperty.php
@@ -12,7 +12,7 @@ class StringProperty implements \JsonSerializable
      */
     public function __construct($foo)
     {
-        $this->foo = $foo;
+        $this->foo = (string)$foo;
     }
 
     public function jsonSerialize()

--- a/tests/examples/SubReference.php
+++ b/tests/examples/SubReference.php
@@ -16,8 +16,8 @@ class SubReference implements \JsonSerializable
      */
     public function __construct($foobar, $baz)
     {
-        $this->foobar = $foobar;
-        $this->baz = $baz;
+        $this->foobar = (string)$foobar;
+        $this->baz = (bool)$baz;
     }
 
     public function jsonSerialize()


### PR DESCRIPTION
Unfortunately as we need to support PHP < 7.0, we need to cast scalar types to avoid nulls being passed in and hence generating invalid JSON.