### PR TITLE
Ordered properties from json schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 # elsevier-io/json-schema-php-generator [![Build Status](https://travis-ci.org/elsevier-io/json-schema-php-generator.svg?branch=master)](https://travis-ci.org/elsevier-io/json-schema-php-generator.svg?branch=master)
 
 
-Tool to generate PHP representations of the data structures in a JSON Schema
+Tool to generate PHP representations of the data structures in a JSON Schema. Entities in the JSON schema are represented 
+by PHP DTOs. Required properties are added via the constructor (respecting the order if it is defined in the JSON) and optional
+properties are added via setters. See the `tests/examples` folder for examples of the PHP created (these examples are used 
+by the tests). 
 
 There is a command-line script to run the tool:
 ```bash

--- a/src/CodeCreator.php
+++ b/src/CodeCreator.php
@@ -152,7 +152,7 @@ class CodeCreator
         $serializableRequiredProperties = '';
         $serializableOptionalProperties = '';
         $propertyOrder;
-        if(isset($schema->propertyOrder)) {
+        if (isset($schema->propertyOrder)) {
             $propertyOrder = $schema->propertyOrder;
         } else {
             $propertyOrder = array_keys(get_object_vars($schema->properties));

--- a/src/CodeCreator.php
+++ b/src/CodeCreator.php
@@ -158,6 +158,7 @@ class CodeCreator
             $propertyNamesInOrder = array_keys(get_object_vars($schema->properties));
         }
         foreach ($propertyNamesInOrder as $propertyName) {
+            // get the attributes from the schema using the property name
             $propertyAttributes = $schema->properties->$propertyName;
             $property = $this->properties->create($propertyName, $propertyAttributes, $className, $this->defaultNamespace);
             if ($this->isRequired($propertyName, $schema)) {

--- a/src/CodeCreator.php
+++ b/src/CodeCreator.php
@@ -151,13 +151,13 @@ class CodeCreator
         $constructor = $class->addMethod('__construct');
         $serializableRequiredProperties = '';
         $serializableOptionalProperties = '';
-        $propertyOrder;
         if (isset($schema->propertyOrder)) {
-            $propertyOrder = $schema->propertyOrder;
+            $propertyNamesInOrder = $schema->propertyOrder;
         } else {
-            $propertyOrder = array_keys(get_object_vars($schema->properties));
+            // if propertyOrder isn't defined in the schema, get property names in the order that they appear in
+            $propertyNamesInOrder = array_keys(get_object_vars($schema->properties));
         }
-        foreach ($propertyOrder as $propertyName) {
+        foreach ($propertyNamesInOrder as $propertyName) {
             $propertyAttributes = $schema->properties->$propertyName;
             $property = $this->properties->create($propertyName, $propertyAttributes, $className, $this->defaultNamespace);
             if ($this->isRequired($propertyName, $schema)) {

--- a/src/CodeCreator.php
+++ b/src/CodeCreator.php
@@ -154,11 +154,9 @@ class CodeCreator
         if (isset($schema->propertyOrder)) {
             $propertyNamesInOrder = $schema->propertyOrder;
         } else {
-            // if propertyOrder isn't defined in the schema, get property names in the order that they appear in
             $propertyNamesInOrder = array_keys(get_object_vars($schema->properties));
         }
         foreach ($propertyNamesInOrder as $propertyName) {
-            // get the attributes from the schema using the property name
             $propertyAttributes = $schema->properties->$propertyName;
             $property = $this->properties->create($propertyName, $propertyAttributes, $className, $this->defaultNamespace);
             if ($this->isRequired($propertyName, $schema)) {

--- a/src/CodeCreator.php
+++ b/src/CodeCreator.php
@@ -151,7 +151,14 @@ class CodeCreator
         $constructor = $class->addMethod('__construct');
         $serializableRequiredProperties = '';
         $serializableOptionalProperties = '';
-        foreach ($schema->properties as $propertyName => $propertyAttributes) {
+        $propertyOrder;
+        if(isset($schema->propertyOrder)) {
+            $propertyOrder = $schema->propertyOrder;
+        } else {
+            $propertyOrder = array_keys(get_object_vars($schema->properties));
+        }
+        foreach ($propertyOrder as $propertyName) {
+            $propertyAttributes = $schema->properties->$propertyName;
             $property = $this->properties->create($propertyName, $propertyAttributes, $className, $this->defaultNamespace);
             if ($this->isRequired($propertyName, $schema)) {
                 $constructor = $property->addConstructorBody($constructor);

--- a/tests/CodeCreatorTest.php
+++ b/tests/CodeCreatorTest.php
@@ -457,6 +457,32 @@ class CodeCreatorTest extends \PHPUnit\Framework\TestCase
         assertThat($code, hasClassThatMatchesTheExample('ConcreteClassTwo'));
     }
 
+    public function testCreateOrderedConstructors()
+    {
+        $schema = json_decode('{
+            "properties": {
+                "alpha": {"type": "string"},
+                "bravo": {"type": "string"},
+                "charlie": {"type": "string"},
+                "delta": {"type": "string"}
+            },
+            "required": [
+                "alpha",
+                "bravo",
+                "charlie"
+            ],
+            "propertyOrder": [
+                "charlie",
+                "bravo",
+                "alpha",
+                "delta"
+            ]
+        }');
+        $codeCreator = $this->buildCodeCreator('MultipleOrderedProperties');
+        $code = $codeCreator->create($schema);
+        assertThat($code, hasClassThatMatchesTheExample('MultipleOrderedProperties'));
+    }
+
     private function buildCodeCreator($defaultClass)
     {
         return new CodeCreator($defaultClass, 'Elsevier\JSONSchemaPHPGenerator\Examples', $this->log);

--- a/tests/CodeCreatorTest.php
+++ b/tests/CodeCreatorTest.php
@@ -459,6 +459,7 @@ class CodeCreatorTest extends \PHPUnit\Framework\TestCase
 
     public function testCreateOrderedConstructors()
     {
+        // constructor is expected to have a subset of properties as 'delta' isn't required. Class will have seperate setter for optional properties.
         $schema = json_decode('{
             "properties": {
                 "alpha": {"type": "string"},

--- a/tests/CodeCreatorTest.php
+++ b/tests/CodeCreatorTest.php
@@ -459,7 +459,6 @@ class CodeCreatorTest extends \PHPUnit\Framework\TestCase
 
     public function testCreateOrderedConstructors()
     {
-        // constructor is expected to have a subset of properties as 'delta' isn't required. Class will have seperate setter for optional properties.
         $schema = json_decode('{
             "properties": {
                 "alpha": {"type": "string"},

--- a/tests/examples/MultipleOrderedProperties.php
+++ b/tests/examples/MultipleOrderedProperties.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Elsevier\JSONSchemaPHPGenerator\Examples;
+
+class MultipleOrderedProperties implements \JsonSerializable
+{
+	/** @var string */
+	private $charlie;
+
+	/** @var string */
+	private $bravo;
+
+	/** @var string */
+	private $alpha;
+
+	/** @var string */
+	private $delta;
+
+
+	/**
+	 * @param string $charlie
+	 * @param string $bravo
+	 * @param string $alpha
+	 */
+	public function __construct($charlie, $bravo, $alpha)
+	{
+		$this->charlie = (string)$charlie;
+		$this->bravo = (string)$bravo;
+		$this->alpha = (string)$alpha;
+	}
+
+
+	/**
+	 * @param string $value
+	 */
+	public function setDelta($value)
+	{
+		$this->delta = $value;
+	}
+
+
+	public function jsonSerialize()
+	{
+		$values = [
+		    'charlie' => $this->charlie,
+		    'bravo' => $this->bravo,
+		    'alpha' => $this->alpha,
+		];
+		if ($this->delta) {
+		   $values['delta'] = $this->delta;
+		}
+		return $values;
+	}
+}

--- a/tests/examples/MultipleOrderedProperties.php
+++ b/tests/examples/MultipleOrderedProperties.php
@@ -4,51 +4,59 @@ namespace Elsevier\JSONSchemaPHPGenerator\Examples;
 
 class MultipleOrderedProperties implements \JsonSerializable
 {
-	/** @var string */
-	private $charlie;
+    /**
+     * @var string
+     */
+    private $charlie;
 
-	/** @var string */
-	private $bravo;
+    /**
+     * @var string
+     */
+    private $bravo;
 
-	/** @var string */
-	private $alpha;
+    /**
+     * @var string
+     */
+    private $alpha;
 
-	/** @var string */
-	private $delta;
-
-
-	/**
-	 * @param string $charlie
-	 * @param string $bravo
-	 * @param string $alpha
-	 */
-	public function __construct($charlie, $bravo, $alpha)
-	{
-		$this->charlie = (string)$charlie;
-		$this->bravo = (string)$bravo;
-		$this->alpha = (string)$alpha;
-	}
+    /**
+     * @var string
+     */
+    private $delta;
 
 
-	/**
-	 * @param string $value
-	 */
-	public function setDelta($value)
-	{
-		$this->delta = $value;
-	}
+    /**
+     * @param string $charlie
+     * @param string $bravo
+     * @param string $alpha
+     */
+    public function __construct($charlie, $bravo, $alpha)
+    {
+        $this->charlie = (string)$charlie;
+        $this->bravo = (string)$bravo;
+        $this->alpha = (string)$alpha;
+    }
 
 
-	public function jsonSerialize()
-	{
-		$values = [
-		    'charlie' => $this->charlie,
-		    'bravo' => $this->bravo,
-		    'alpha' => $this->alpha,
-		];
-		if ($this->delta) {
-		   $values['delta'] = $this->delta;
-		}
-		return $values;
-	}
+    /**
+     * @param string $value
+     */
+    public function setDelta($value)
+    {
+        $this->delta = $value;
+    }
+
+
+    public function jsonSerialize()
+    {
+        $values = [
+         'charlie' => $this->charlie,
+         'bravo' => $this->bravo,
+         'alpha' => $this->alpha,
+        ];
+        if ($this->delta) {
+            $values['delta'] = $this->delta;
+        }
+        return $values;
+    }
 }

--- a/tests/examples/MultipleOrderedProperties.php
+++ b/tests/examples/MultipleOrderedProperties.php
@@ -4,24 +4,16 @@ namespace Elsevier\JSONSchemaPHPGenerator\Examples;
 
 class MultipleOrderedProperties implements \JsonSerializable
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     private $charlie;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     private $bravo;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     private $alpha;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     private $delta;
 
 


### PR DESCRIPTION
If the json schema contains `propertyOrder` then the properties in the constructor of the generated php file should be in the defined order. 