### PR TITLE
Add support for arrays of scalars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [unreleased]
+### Added
+- Add support for properties that contain an array of scalars
+### Fixed
+- Fix issue where generated code would produce invalid JSON for filtered array properties (as numeric keys in PHP were preserved)
+
 ## [0.8.0] - 2018-04-16
 ### Added
 - Add support for propertyOrder

--- a/README.md
+++ b/README.md
@@ -22,3 +22,4 @@ So far this is only a partial implementation of the JSON Schema. See tests for w
 - Add support for nulls
 - Ensure generator can handle all valid JSON Schemas (Schemata?)
 - Parse schema to AST before generating code (so we can create different code generators)
+- Add option to toggle between swallowing invalid values and throwing in generated code 

--- a/src/Properties/ArrayProperty.php
+++ b/src/Properties/ArrayProperty.php
@@ -83,9 +83,9 @@ class ArrayProperty extends TypedProperty
             ->setVisibility('private')
             ->addComment("@param array \$array\n@return $this->type")
             ->addBody(<<<CODE
-return array_filter(\$array, function (\$item) {
+return array_values(array_filter(\$array, function (\$item) {
    return {$this->itemFilter};
-});
+}));
 CODE
             )
             ->addParameter('array')

--- a/src/Properties/ArrayProperty.php
+++ b/src/Properties/ArrayProperty.php
@@ -15,6 +15,14 @@ class ArrayProperty extends TypedProperty
      * @var string
      */
     protected $namespace;
+    /**
+     * @var string
+     */
+    protected $filterMethodName;
+    /**
+     * @var string
+     */
+    protected $itemFilter;
 
     /**
      * @param string $name
@@ -26,6 +34,12 @@ class ArrayProperty extends TypedProperty
         $this->namespace = $namespace;
         $this->arrayItemType = $type;
         parent::__construct($name, $type . '[]');
+        $this->filterMethodName = 'filterFor' . ucfirst($this->arrayItemType);
+        if (array_search($type, ['string', 'float', 'boolean']) !== false) {
+            $this->itemFilter = "is_{$this->arrayItemType}(\$item)";
+        } else {
+            $this->itemFilter = "\$item instanceof {$this->arrayItemType}";
+        }
     }
 
     /**
@@ -43,7 +57,7 @@ class ArrayProperty extends TypedProperty
      */
     public function addConstructorBody(Method $constructor)
     {
-        $constructor->addBody("\$this->{$this->name} = \$this->filterFor{$this->arrayItemType}(\${$this->name});");
+        $constructor->addBody("\$this->{$this->name} = \$this->{$this->filterMethodName}(\${$this->name});");
         return $constructor;
     }
 
@@ -54,7 +68,7 @@ class ArrayProperty extends TypedProperty
     {
         $class->addMethod('set' . ucfirst($this->name))
             ->addComment("@param {$this->type} \$value")
-            ->addBody("\$this->{$this->name} = \$this->filterFor{$this->arrayItemType}(\$value);")
+            ->addBody("\$this->{$this->name} = \$this->{$this->filterMethodName}(\$value);")
             ->addParameter('value')
             ->setTypeHint('array');
         return $class;
@@ -65,12 +79,12 @@ class ArrayProperty extends TypedProperty
      */
     public function addExtraMethodsTo(ClassType $class)
     {
-        $class->addMethod('filterFor' . $this->arrayItemType)
+        $class->addMethod($this->filterMethodName)
             ->setVisibility('private')
             ->addComment("@param array \$array\n@return $this->type")
             ->addBody(<<<CODE
 return array_filter(\$array, function (\$item) {
-   return \$item instanceof {$this->arrayItemType};
+   return {$this->itemFilter};
 });
 CODE
             )

--- a/src/Properties/Factory.php
+++ b/src/Properties/Factory.php
@@ -61,7 +61,9 @@ class Factory
             return new BooleanProperty($name);
         } elseif ($attributes->type === 'array') {
             $this->log->debug('Created Array property ' . $name);
-            return new ArrayProperty($name, $this->extractTypeFromRef($attributes->items->{'$ref'}), $namespace);
+            $arrayItemType = isset($attributes->items->{'$ref'}) ? $this->extractTypeFromRef($attributes->items->{'$ref'}) : $this->extractTypeFromRef($attributes->items->{'type'});
+            $arrayItemType = $arrayItemType === 'number' ? 'float' : $arrayItemType;
+            return new ArrayProperty($name, $arrayItemType, $namespace);
         }
         return new UntypedProperty();
     }

--- a/tests/CodeCreatorTest.php
+++ b/tests/CodeCreatorTest.php
@@ -340,6 +340,36 @@ class CodeCreatorTest extends \PHPUnit\Framework\TestCase
         assertThat($code, hasClassThatMatchesTheExample('ArrayOfObjects'));
     }
 
+    public function testWithArrayOfScalarTypes()
+    {
+        $schema = json_decode('{
+            "properties": {
+                "bar": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "foo": {
+                    "items": {
+                        "type": "number"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object",
+            "required": [
+                "bar"
+            ]
+        }');
+        $codeCreator = $this->buildCodeCreator('ArrayOfScalars');
+
+        $code = $codeCreator->create($schema);
+
+        assertThat($code, arrayWithSize(atLeast(1)));
+        assertThat($code, hasClassThatMatchesTheExample('ArrayOfScalars'));
+    }
+
     public function testWithInterfacePropertyCreatesReferencingClass()
     {
         $schema = json_decode('{

--- a/tests/JSONOutput/ArrayOfObjectsTest.php
+++ b/tests/JSONOutput/ArrayOfObjectsTest.php
@@ -64,8 +64,8 @@ class ArrayOfObjectsTest extends TestCase
     public function testFiltersArrayForInvalidValues()
     {
         $subReferences = [
-            new SubReference("foo", true),
             "string",
+            new SubReference("foo", true),
             true
         ];
         $object = new ArrayOfObjects($subReferences);

--- a/tests/JSONOutput/ArrayOfScalarsTest.php
+++ b/tests/JSONOutput/ArrayOfScalarsTest.php
@@ -51,8 +51,8 @@ class ArrayOfScalarsTest extends TestCase
     public function testFiltersArrayForInvalidValues()
     {
         $subReferences = [
-            "string",
             new \StdClass("foo", true),
+            "string",
             true
         ];
         $object = new ArrayOfScalars($subReferences);

--- a/tests/JSONOutput/ArrayOfScalarsTest.php
+++ b/tests/JSONOutput/ArrayOfScalarsTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Elsevier\JSONSchemaPHPGenerator\Tests\JSONOutput;
+
+use Elsevier\JSONSchemaPHPGenerator\Examples\ArrayOfScalars;
+use PHPUnit\Framework\TestCase;
+
+class ArrayOfScalarsTest extends TestCase
+{
+    public function testOutputsSimpleRequiredArray()
+    {
+        $strings = [
+            "baz",
+            "bar",
+        ];
+        $object = new ArrayOfScalars($strings);
+        $json = json_encode($object);
+
+        $expected = '{
+            "bar": [
+                "baz",
+                "bar"
+            ]
+        }';
+        assertThat($json, matchesJSONOutput($expected));
+    }
+
+    public function testOutputsRequiredAndOptionalArray()
+    {
+        $requiredStrings = [
+            "baz",
+        ];
+        $optionalFloats = [
+            1.23
+        ];
+        $object = new ArrayOfScalars($requiredStrings);
+        $object->setFoo($optionalFloats);
+        $json = json_encode($object);
+
+        $expected = '{
+            "bar": [
+                "baz"
+            ],
+            "foo": [
+                1.23
+            ]
+        }';
+        assertThat($json, matchesJSONOutput($expected));
+    }
+
+    public function testFiltersArrayForInvalidValues()
+    {
+        $subReferences = [
+            "string",
+            new \StdClass("foo", true),
+            true
+        ];
+        $object = new ArrayOfScalars($subReferences);
+        $json = json_encode($object);
+
+        $expected = '{
+            "bar": [
+                "string"
+            ]
+        }';
+        assertThat($json, matchesJSONOutput($expected));
+    }
+}

--- a/tests/examples/ArrayOfObjects.php
+++ b/tests/examples/ArrayOfObjects.php
@@ -23,9 +23,9 @@ class ArrayOfObjects implements \JsonSerializable
      */
     private function filterForSubReference(array $array)
     {
-        return array_filter($array, function ($item) {
+        return array_values(array_filter($array, function ($item) {
             return $item instanceof SubReference;
-        });
+        }));
     }
 
     /**

--- a/tests/examples/ArrayOfScalars.php
+++ b/tests/examples/ArrayOfScalars.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Elsevier\JSONSchemaPHPGenerator\Examples;
+
+class ArrayOfScalars implements \JsonSerializable
+{
+    /** @var string[] */
+    private $bar;
+    /** @var float[] */
+    private $foo;
+
+    /**
+     * @param string[] $bar
+     */
+    public function __construct(array $bar)
+    {
+        $this->bar = $this->filterForString($bar);
+    }
+
+    /**
+     * @param array $array
+     * @return string[]
+     */
+    private function filterForString(array $array)
+    {
+        return array_filter($array, function ($item) {
+            return is_string($item);
+        });
+    }
+
+    /**
+     * @param float[] $value
+     */
+    public function setFoo(array $value)
+    {
+        $this->foo = $this->filterForFloat($value);
+    }
+
+    /**
+     * @param array $array
+     * @return float[]
+     */
+    private function filterForFloat(array $array)
+    {
+        return array_filter($array, function ($item) {
+            return is_float($item);
+        });
+    }
+
+    public function jsonSerialize()
+    {
+        $values = [
+            'bar' => $this->bar,
+        ];
+        if ($this->foo) {
+            $values['foo'] = $this->foo;
+        }
+        return $values;
+    }
+}

--- a/tests/examples/ArrayOfScalars.php
+++ b/tests/examples/ArrayOfScalars.php
@@ -23,9 +23,9 @@ class ArrayOfScalars implements \JsonSerializable
      */
     private function filterForString(array $array)
     {
-        return array_filter($array, function ($item) {
+        return array_values(array_filter($array, function ($item) {
             return is_string($item);
-        });
+        }));
     }
 
     /**
@@ -42,9 +42,9 @@ class ArrayOfScalars implements \JsonSerializable
      */
     private function filterForFloat(array $array)
     {
-        return array_filter($array, function ($item) {
+        return array_values(array_filter($array, function ($item) {
             return is_float($item);
-        });
+        }));
     }
 
     public function jsonSerialize()


### PR DESCRIPTION
This raised an interesting question of what to do in the generated PHP when an array is provided for an array property that doesn't match the required type. Currently we silently filter out any values that don't match. See for example https://github.com/elsevier-io/json-schema-php-generator/pull/18/files#diff-f652da025f486dbfa4910a2d1eb08ac9R51

The other option I can think of would be to throw if invalid values were passed in. I'm thinking that might be a better option?