### PR TITLE
Non required types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [unreleased] - 2018-10-04
+### Added
+- Add support for type that aren't required
+
 ## [0.9.0] - 2018-07-03
 ### Added
 - Add support for properties that contain an array of scalars

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [unreleased] - 2018-10-04
+## [0.10.0] - 2018-10-04
 ### Added
 - Add support for type that aren't required
 

--- a/src/CodeCreator.php
+++ b/src/CodeCreator.php
@@ -68,9 +68,6 @@ class CodeCreator
     private function isRequired($property, $schema)
     {
         $requiredProperties = (isset($schema->required)) ? $schema->required : [];
-        if (isset($schema->properties->$property->anyOf)){
-            $requiredProperties[] = $property;
-        }
         return in_array($property, $requiredProperties);
     }
 
@@ -170,6 +167,9 @@ class CodeCreator
                 $serializableRequiredProperties .= $property->serializingCode();
                 $classes = array_merge($classes, $property->extraClasses($this));
             } else {
+                if (isset($schema->properties->$propertyName->anyOf)){
+                    $classes = array_merge($classes, $property->extraClasses($this));
+                }
                 $class = $property->addTo($class);
                 $class = $property->addSetterTo($class);
                 $serializableOptionalProperties .= $property->optionalSerializingCode();

--- a/src/CodeCreator.php
+++ b/src/CodeCreator.php
@@ -167,7 +167,7 @@ class CodeCreator
                 $serializableRequiredProperties .= $property->serializingCode();
                 $classes = array_merge($classes, $property->extraClasses($this));
             } else {
-                if (isset($schema->properties->$propertyName->anyOf)){
+                if (isset($schema->properties->$propertyName->anyOf)) {
                     $classes = array_merge($classes, $property->extraClasses($this));
                 }
                 $class = $property->addTo($class);

--- a/src/CodeCreator.php
+++ b/src/CodeCreator.php
@@ -67,7 +67,10 @@ class CodeCreator
 
     private function isRequired($property, $schema)
     {
-        $requiredProperties = isset($schema->required) ? $schema->required : [];
+        $requiredProperties = (isset($schema->required)) ? $schema->required : [];
+        if (isset($schema->properties->$property->anyOf)){
+            $requiredProperties[] = $property;
+        }
         return in_array($property, $requiredProperties);
     }
 

--- a/src/CodeCreator.php
+++ b/src/CodeCreator.php
@@ -67,7 +67,7 @@ class CodeCreator
 
     private function isRequired($property, $schema)
     {
-        $requiredProperties = (isset($schema->required)) ? $schema->required : [];
+        $requiredProperties = isset($schema->required) ? $schema->required : [];
         return in_array($property, $requiredProperties);
     }
 

--- a/tests/CodeCreatorTest.php
+++ b/tests/CodeCreatorTest.php
@@ -513,79 +513,63 @@ class CodeCreatorTest extends \PHPUnit\Framework\TestCase
         assertThat($code, hasClassThatMatchesTheExample('MultipleOrderedProperties'));
     }
 
-    public function testStoreSpecificInterfaceIsCreated() {
+    public function testUnRequieredTypeIsCreated() {
         $schema = json_decode('{
             "definitions": {
-                "IEvolve": {
+                "ICharlie": {
                     "additionalProperties": false,
                     "properties": {
-                        "affiliationBillTo": {
-                            "type": "string"
-                        },
-                        "affiliationCustomerId": {
-                            "type": "string"
-                        },
-                        "deltaAccountId": {
-                            "type": "string"
-                        },
-                        "salesRepNumber": {
+                        "charlie": {
                             "type": "string"
                         }
                     },
                     "propertyOrder": [
-                        "deltaAccountId",
-                        "affiliationCustomerId",
-                        "affiliationBillTo",
-                        "salesRepNumber"
+                        "charlie"
                     ],
                     "required": [
-                        "affiliationCustomerId",
-                        "deltaAccountId",
-                        "salesRepNumber"
+                        "charlie"
                     ],
                     "type": "object"
                 },
-                "IPointOfSale": {
+                "IBravo": {
                     "additionalProperties": false,
                     "properties": {
-                        "consignee": {
-                            "type": "string"
-                        },
-                        "salesRepNumber": {
+                        "bravo": {
                             "type": "string"
                         }
                     },
                     "propertyOrder": [
-                        "salesRepNumber",
-                        "consignee"
+                        "bravo"
                     ],
                     "required": [
-                        "consignee",
-                        "salesRepNumber"
+                        "bravo"
                     ],
                     "type": "object"
                 }
             },
             "properties": {
-                "storeSpecific": {
+                "bar": {
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/IEvolve"
+                            "$ref": "#/definitions/ICharlie"
                         },
                         {
-                            "$ref": "#/definitions/IPointOfSale"
+                            "$ref": "#/definitions/IBravo"
                         }
                     ]
                 }
             },
             "propertyOrder": [
-                "storeSpecific"
+                "bar"
             ]
         }');
 
-        $codeCreator = new CodeCreator($defaultClass, 'Elsevier\JSONSchemaPHPGenerator\Examples', $this->log);
+        $codeCreator = $this->buildCodeCreator('InterfaceProperty');
+
+        $code = $codeCreator->create($schema);
 
         assertThat($code, arrayWithSize(atLeast(1)));
+        assertThat($code, hasClassThatMatchesTheExample('IBar'));
     }
 
     private function buildCodeCreator($defaultClass)

--- a/tests/CodeCreatorTest.php
+++ b/tests/CodeCreatorTest.php
@@ -513,7 +513,8 @@ class CodeCreatorTest extends \PHPUnit\Framework\TestCase
         assertThat($code, hasClassThatMatchesTheExample('MultipleOrderedProperties'));
     }
 
-    public function testUnrequieredTypeIsCreated() {
+    public function testUnrequieredTypeIsCreated()
+    {
         $schema = json_decode('{
             "definitions": {
                 "ICharlie": {

--- a/tests/CodeCreatorTest.php
+++ b/tests/CodeCreatorTest.php
@@ -513,7 +513,7 @@ class CodeCreatorTest extends \PHPUnit\Framework\TestCase
         assertThat($code, hasClassThatMatchesTheExample('MultipleOrderedProperties'));
     }
 
-    public function testUnrequieredTypeIsCreated()
+    public function testUnrequiredTypeIsCreated()
     {
         $schema = json_decode('{
             "definitions": {

--- a/tests/CodeCreatorTest.php
+++ b/tests/CodeCreatorTest.php
@@ -513,7 +513,7 @@ class CodeCreatorTest extends \PHPUnit\Framework\TestCase
         assertThat($code, hasClassThatMatchesTheExample('MultipleOrderedProperties'));
     }
 
-    public function testUnRequieredTypeIsCreated() {
+    public function testUnrequieredTypeIsCreated() {
         $schema = json_decode('{
             "definitions": {
                 "ICharlie": {


### PR DESCRIPTION
# Description

This fix makes sure that a php interface is created for a type, even if this one isn't required
This shouldn't be a breaking change, but we are not sure.
We did a test against submit-order-types and it worked

## Type of change

Select all that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This is a documentation update
- [ ] This is a configuration update
- [ ] Refactoring

# Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If making changed to dependencies, I have updated package-lock.json