### PR TITLE
Add support for min length max length

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
     }],
     "require": {
         "php" : "^5.5 || ^7.0",
+        "ext-json": "*",
         "ext-mbstring": "*",
         "league/flysystem": "^1.0",
         "nette/php-generator": "2.3.*",

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
     }],
     "require": {
         "php" : "^5.5 || ^7.0",
+        "ext-mbstring": "*",
         "league/flysystem": "^1.0",
         "nette/php-generator": "2.3.*",
         "nette/utils": "2.3.*",

--- a/src/Properties/Factory.php
+++ b/src/Properties/Factory.php
@@ -54,8 +54,9 @@ class Factory
             $this->log->debug('Created Float property ' . $name);
             return new FloatProperty($name);
         } elseif ($attributes->type === 'string' && !isset($attributes->enum)) {
+            $minLength = isset($attributes->minLength) ? $attributes->minLength : false;
             $this->log->debug('Created String property ' . $name);
-            return new StringProperty($name);
+            return new StringProperty($name, $minLength);
         } elseif ($attributes->type === 'boolean') {
             $this->log->debug('Created Boolean property ' . $name);
             return new BooleanProperty($name);

--- a/src/Properties/Factory.php
+++ b/src/Properties/Factory.php
@@ -55,8 +55,9 @@ class Factory
             return new FloatProperty($name);
         } elseif ($attributes->type === 'string' && !isset($attributes->enum)) {
             $minLength = isset($attributes->minLength) ? $attributes->minLength : false;
+            $maxLength = isset($attributes->maxLength) ? $attributes->maxLength : false;
             $this->log->debug('Created String property ' . $name);
-            return new StringProperty($name, $minLength);
+            return new StringProperty($name, $minLength, $maxLength);
         } elseif ($attributes->type === 'boolean') {
             $this->log->debug('Created Boolean property ' . $name);
             return new BooleanProperty($name);

--- a/src/Properties/StringProperty.php
+++ b/src/Properties/StringProperty.php
@@ -2,16 +2,30 @@
 
 namespace Elsevier\JSONSchemaPHPGenerator\Properties;
 
+use Nette\PhpGenerator\ClassType;
 use Nette\PhpGenerator\Method;
 
 class StringProperty extends TypedProperty
 {
     /**
-     * @param string $name
+     * @var integer|false
      */
-    public function __construct($name)
+    private $minLength;
+    /**
+     * @var integer|false
+     */
+    private $maxLength;
+
+    /**
+     * @param string $name
+     * @param integer|false $minLength
+     * @param integer|false $maxLength
+     */
+    public function __construct($name, $minLength = false, $maxLength = false)
     {
         parent::__construct($name, 'string');
+        $this->minLength = $minLength;
+        $this->maxLength = $maxLength;
     }
 
     /**
@@ -19,7 +33,31 @@ class StringProperty extends TypedProperty
      */
     public function addConstructorBody(Method $constructor)
     {
-        $constructor->addBody("\$this->{$this->name} = (string)\${$this->name};");
+        $value = "(string)\${$this->name}";
+        if ($this->minLength !== false) {
+            $value = "\$this->ensureMinimumLength($value)";
+        }
+        $constructor->addBody("\$this->{$this->name} = {$value};");
         return $constructor;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function addExtraMethodsTo(ClassType $class)
+    {
+        if ($this->minLength !== false) {
+            $body = <<<BODY
+                if (mb_strlen(\$value) < {$this->minLength}) {
+                throw new InvalidValueException(\$value . ' is less than the minimum specified length of {$this->minLength}');
+                }
+                return \$value;
+BODY;
+            $class->addMethod('ensureMinimumLength')
+                ->setVisibility('private')
+                ->addBody($body)
+                ->addParameter('value');
+        }
+        return $class;
     }
 }

--- a/src/Properties/StringProperty.php
+++ b/src/Properties/StringProperty.php
@@ -37,6 +37,9 @@ class StringProperty extends TypedProperty
         if ($this->minLength !== false) {
             $value = "\$this->ensureMinimumLength($value)";
         }
+        if ($this->maxLength !== false) {
+            $value = "\$this->ensureMaximumLength($value)";
+        }
         $constructor->addBody("\$this->{$this->name} = {$value};");
         return $constructor;
     }
@@ -49,11 +52,23 @@ class StringProperty extends TypedProperty
         if ($this->minLength !== false) {
             $body = <<<BODY
                 if (mb_strlen(\$value) < {$this->minLength}) {
-                throw new InvalidValueException(\$value . ' is less than the minimum specified length of {$this->minLength}');
+                    throw new InvalidValueException(\$value . ' is less than the minimum specified length of {$this->minLength}');
                 }
                 return \$value;
 BODY;
             $class->addMethod('ensureMinimumLength')
+                ->setVisibility('private')
+                ->addBody($body)
+                ->addParameter('value');
+        }
+        if ($this->maxLength !== false) {
+            $body = <<<BODY
+                if (mb_strlen(\$value) > {$this->maxLength}) {
+                    throw new InvalidValueException(\$value . ' is more than the maximum specified length of {$this->maxLength}');
+                }
+                return \$value;
+BODY;
+            $class->addMethod('ensureMaximumLength')
                 ->setVisibility('private')
                 ->addBody($body)
                 ->addParameter('value');

--- a/tests/CodeCreatorTest.php
+++ b/tests/CodeCreatorTest.php
@@ -573,6 +573,28 @@ class CodeCreatorTest extends \PHPUnit\Framework\TestCase
         assertThat($code, hasClassThatMatchesTheExample('IBar'));
     }
 
+    public function testStringMinLength()
+    {
+        $schema = json_decode('{
+            "properties": {
+                "foo": {
+                    "type": "string",
+                    "minLength": 1
+                }
+            },
+            "required": [
+                "foo"
+            ]
+        }');
+
+        $codeCreator = $this->buildCodeCreator('StringPropertyWithLengthValidation');
+
+        $code = $codeCreator->create($schema);
+
+        assertThat($code, arrayWithSize(atLeast(1)));
+        assertThat($code, hasClassThatMatchesTheExample('StringPropertyWithLengthValidation'));
+    }
+
     private function buildCodeCreator($defaultClass)
     {
         return new CodeCreator($defaultClass, 'Elsevier\JSONSchemaPHPGenerator\Examples', $this->log);

--- a/tests/CodeCreatorTest.php
+++ b/tests/CodeCreatorTest.php
@@ -579,7 +579,8 @@ class CodeCreatorTest extends \PHPUnit\Framework\TestCase
             "properties": {
                 "foo": {
                     "type": "string",
-                    "minLength": 1
+                    "minLength": 1,
+                    "maxLength": 15
                 }
             },
             "required": [

--- a/tests/JSONOutput/StringPropertyWithLengthValidationTest.php
+++ b/tests/JSONOutput/StringPropertyWithLengthValidationTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Elsevier\JSONSchemaPHPGenerator\Tests\JSONOutput;
+
+use Elsevier\JSONSchemaPHPGenerator\Examples\InvalidValueException;
+use Elsevier\JSONSchemaPHPGenerator\Examples\StringPropertyWithLengthValidation;
+use PHPUnit\Framework\TestCase;
+
+class StringPropertyWithLengthValidationTest extends TestCase
+{
+    public function testRejectsStringLessThanMinLength()
+    {
+        try {
+            $object = new StringPropertyWithLengthValidation('');
+            assertThat(true, is(false));
+        } catch (\Exception $e) {
+            assertThat($e, is(anInstanceOf(InvalidValueException::class)));
+        }
+    }
+
+    public function testRejectsStringMoreThanMaxLength()
+    {
+        try {
+            $object = new StringPropertyWithLengthValidation(str_repeat('a', 16));
+            assertThat(true, is(false));
+        } catch (\Exception $e) {
+            assertThat($e, is(anInstanceOf(InvalidValueException::class)));
+        }
+    }
+
+    public function testAcceptsStringWithinLengthBounds()
+    {
+        $object = new StringPropertyWithLengthValidation('bar');
+        $json = json_encode($object);
+
+        $expected = '{
+            "foo": "bar"
+        }';
+        assertThat($json, matchesJSONOutput($expected));
+    }
+}

--- a/tests/examples/StringPropertyWithLengthValidation.php
+++ b/tests/examples/StringPropertyWithLengthValidation.php
@@ -12,13 +12,21 @@ class StringPropertyWithLengthValidation implements \JsonSerializable
      */
     public function __construct($foo)
     {
-        $this->foo = $this->ensureMinimumLength((string)$foo);
+        $this->foo = $this->ensureMaximumLength($this->ensureMinimumLength((string)$foo));
     }
 
     private function ensureMinimumLength($value)
     {
         if (mb_strlen($value) < 1) {
             throw new InvalidValueException($value . ' is less than the minimum specified length of 1');
+        }
+        return $value;
+    }
+
+    private function ensureMaximumLength($value)
+    {
+        if (mb_strlen($value) > 15) {
+            throw new InvalidValueException($value . ' is more than the maximum specified length of 15');
         }
         return $value;
     }

--- a/tests/examples/StringPropertyWithLengthValidation.php
+++ b/tests/examples/StringPropertyWithLengthValidation.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Elsevier\JSONSchemaPHPGenerator\Examples;
+
+class StringPropertyWithLengthValidation implements \JsonSerializable
+{
+    /** @var string */
+    private $foo;
+
+    /**
+     * @param string $foo
+     */
+    public function __construct($foo)
+    {
+        $this->foo = $this->ensureMinimumLength((string)$foo);
+    }
+
+    private function ensureMinimumLength($value)
+    {
+        if (mb_strlen($value) < 1) {
+            throw new InvalidValueException($value . ' is less than the minimum specified length of 1');
+        }
+        return $value;
+    }
+
+    public function jsonSerialize()
+    {
+        return [
+            'foo' => $this->foo,
+        ];
+    }
+}


### PR DESCRIPTION
As per http://json-schema.org/draft-04/schema# string types can have min and max lengths set. This PR adds support for those properties and validates any strings as a result.