### PR TITLE
Add test to ensure Exception gets created

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [unreleased]
+### Fixed
+- Ensure Exception class gets created if string property has constraint(s)
+
 ## [0.11.2] - 2018-11-05
 ### Fixed
 - Tidy up indentation on string length validation

--- a/src/Properties/StringProperty.php
+++ b/src/Properties/StringProperty.php
@@ -16,6 +16,10 @@ class StringProperty extends TypedProperty
      * @var integer|false
      */
     private $maxLength;
+    /**
+     * @var boolean
+     */
+    private $hasConstraint;
 
     /**
      * @param string $name
@@ -27,6 +31,7 @@ class StringProperty extends TypedProperty
         parent::__construct($name, 'string');
         $this->minLength = $minLength;
         $this->maxLength = $maxLength;
+        $this->hasConstraint = ($this->minLength !== false || $this->maxLength !== false);
     }
 
     /**
@@ -76,7 +81,7 @@ BODY;
     public function extraClasses(CodeCreator $code)
     {
         $classes = [];
-        if ($this->minLength !== false || $this->maxLength !== false) {
+        if ($this->hasConstraint) {
             $classes['InvalidValueException'] = $code->createException('InvalidValueException');
         }
         return $classes;
@@ -87,7 +92,7 @@ BODY;
      */
     public function addSetterTo(ClassType $class)
     {
-        if ($this->minLength !== false || $this->maxLength !== false) {
+        if ($this->hasConstraint) {
             $class->addMethod('set' . ucfirst($this->name))
                 ->addComment('@param ' . $this->type . ' $' . $this->name)
                 ->addComment('@throws InvalidValueException')
@@ -108,7 +113,7 @@ BODY;
     protected function getCodeToAssignValue()
     {
         $value = "(string)\${$this->name}";
-        if ($this->minLength !== false || $this->maxLength !== false) {
+        if ($this->hasConstraint) {
             if ($this->minLength !== false) {
                 $value = "\$this->ensureMinimumLength($value)";
             }
@@ -121,7 +126,7 @@ BODY;
 
     public function getConstructorException(array $constructorExceptions)
     {
-        if ($this->minLength !== false || $this->maxLength !== false) {
+        if ($this->hasConstraint) {
             $constructorExceptions[] = 'InvalidValueException';
         }
         return $constructorExceptions;

--- a/src/Properties/StringProperty.php
+++ b/src/Properties/StringProperty.php
@@ -2,6 +2,7 @@
 
 namespace Elsevier\JSONSchemaPHPGenerator\Properties;
 
+use Elsevier\JSONSchemaPHPGenerator\CodeCreator;
 use Nette\PhpGenerator\ClassType;
 use Nette\PhpGenerator\Method;
 
@@ -67,6 +68,18 @@ BODY;
                 ->addParameter('value');
         }
         return $class;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function extraClasses(CodeCreator $code)
+    {
+        $classes = [];
+        if ($this->minLength !== false || $this->maxLength !== false) {
+            $classes['InvalidValueException'] = $code->createException('InvalidValueException');
+        }
+        return $classes;
     }
 
     /**

--- a/tests/CodeCreatorTest.php
+++ b/tests/CodeCreatorTest.php
@@ -573,7 +573,7 @@ class CodeCreatorTest extends \PHPUnit\Framework\TestCase
         assertThat($code, hasClassThatMatchesTheExample('IBar'));
     }
 
-    public function testStringMinLength()
+    public function testStringLengthConstraints()
     {
         $schema = json_decode('{
             "properties": {
@@ -603,8 +603,9 @@ class CodeCreatorTest extends \PHPUnit\Framework\TestCase
 
         $code = $codeCreator->create($schema);
 
-        assertThat($code, arrayWithSize(atLeast(1)));
+        assertThat($code, arrayWithSize(atLeast(2)));
         assertThat($code, hasClassThatMatchesTheExample('StringPropertyWithLengthValidation'));
+        assertThat($code, hasClassThatMatchesTheExample('InvalidValueException'));
     }
 
     private function buildCodeCreator($defaultClass)


### PR DESCRIPTION
Realised we forgot to ensure the Exception class gets created. This didn't ultimately matter when we used it as the Exception was already created by an Enum but could catch us out in the future.